### PR TITLE
Opening all-in hands

### DIFF
--- a/src/common/game/game-play.ts
+++ b/src/common/game/game-play.ts
@@ -6,22 +6,23 @@ import { solveHands } from "./solve-hands";
 import { updatePots } from "./update-pots";
 
 export class GamePlay implements GamePlayType {
-  public gameID: string;
-  public cardBack: string;
-  public bigBlind: number;
-  public littleBlind: number;
   public players: PlayerType[] = [];
   public board: string[] = [];
-  public round: number = 0;
-  public pot: number = 0;
-  public currentBet: number = 0;
-  public currentPot: number = 0;
-  public currentPlayerID: string = "";
-  public winDesc: string = "";
   public pots: number[] = [];
   public deck: string[] = [];
-  public isStarted: boolean = false;
+  public currentPlayerID: string = "";
+  public winDesc: string = "";
+  public cardBack: string;
+  public gameID: string;
+  public currentBet: number = 0;
+  public currentPot: number = 0;
+  public round: number = 0;
+  public pot: number = 0;
+  public littleBlind: number;
+  public bigBlind: number;
   public isGameOver: boolean = false;
+  public isStarted: boolean = false;
+  public isOpen: boolean = false;
 
   get dealerIndex(): number {
     return this.players.findIndex((player) => player.dealer === true);
@@ -129,7 +130,6 @@ export class GamePlay implements GamePlayType {
     }
 
     player.status = action;
-
     this.nextTurn();
   }
 
@@ -189,6 +189,7 @@ export class GamePlay implements GamePlayType {
     this.pot = 0;
     this.winDesc = "";
     this.isGameOver = false;
+    this.isOpen = false;
   }
 
   private clearPlayers(active: boolean = false): void {

--- a/src/common/game/game.ts
+++ b/src/common/game/game.ts
@@ -15,9 +15,10 @@ export class Game extends GamePlay {
     return {
       board: this.board,
       gameID: this.gameID,
-      players: this.isGameOver
-        ? this.players
-        : this.getGameStatePlayers(currentPlayerID),
+      players:
+        this.isGameOver || this.isOpen
+          ? this.players
+          : this.getGameStatePlayers(currentPlayerID),
       pot: this.pot,
       round: this.round,
       bigBlind: this.bigBlind,
@@ -30,6 +31,7 @@ export class Game extends GamePlay {
       pots: this.pots,
       isGameOver: this.isGameOver,
       isStarted: this.isStarted,
+      isOpen: this.isOpen,
       sittingInPlayers: this.sittingInPlayers,
     };
   }
@@ -72,5 +74,20 @@ export class Game extends GamePlay {
     }
 
     this.actionPlayed(player, action, dataNum);
+  }
+
+  public OpenGame(callback: () => void): void {
+    this.updateRound();
+    callback();
+
+    if (this.isGameOver) {
+      setTimeout(() => {
+        this.start();
+        callback();
+      }, 5000);
+      return;
+    }
+
+    setTimeout(() => this.OpenGame(callback), 3000);
   }
 }

--- a/src/common/game/next-turn.ts
+++ b/src/common/game/next-turn.ts
@@ -6,6 +6,14 @@ export function nextTurn(game: GamePlayType): void {
 
   game.players[game.playerTurnIndex].isTurn = false;
 
+  // all players in the pot are all-in, or one player is playing alone against opponents who are all all-in
+  if (
+    game.activePlayers.filter((player) => player.stackAmount > 0).length <= 1
+  ) {
+    game.isOpen = true;
+    return;
+  }
+
   // While next player Doesnt Exist, isn't Active, has no stack or is sitting out
   while (
     !game.players[nextPlayerIndex] ||

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -42,6 +42,7 @@ export interface GameState {
   pots: number[];
   isStarted: boolean;
   isGameOver: boolean;
+  isOpen: boolean;
   readonly sittingInPlayers: PlayerType[];
 }
 

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -76,6 +76,11 @@ export function createSocket(server: Server) {
         game.playerAction(player, action, data);
         sendGameState(io, game);
 
+        if (game.isOpen) {
+          game.OpenGame(() => sendGameState(io, game));
+          return;
+        }
+
         // Game has ended, show last cards and winning desc then wait 5 secs and start a new game
         if (game.winDesc !== "") {
           setTimeout(() => {


### PR DESCRIPTION
Showdown vs Opening All-in Hands is a bit different it seems

Opening all-in hands

> When all players in the pot are all-in, or one player is playing alone against opponents who are all all-in, no more betting can take place. 

Showdown 

> When, if more than one player remains after the last betting round, remaining players expose and compare their hands to determine the winner or winners.

This takes care of if everyone is all in, take over control and update each round every 3 seconds